### PR TITLE
removes unused import

### DIFF
--- a/src/soap.service.ts
+++ b/src/soap.service.ts
@@ -1,6 +1,5 @@
 import { Injectable } from '@angular/core';
 import { Observable } from "rxjs/Observable";
-import 'rxjs/add/operator/map';
 import { createSoapClient } from "./libts/soap";
 import { Client, ClientOptions} from "./libts/client";
 import { HttpClient } from '@angular/common/http';


### PR DESCRIPTION
updating a project to angular 6 (and thus rxjs6) leads to some error with this import.
It seems that map itself isn't even used here, so i see no reason having it in the file, no?