### PR TITLE
Added MTOM support

### DIFF
--- a/projects/ngx-soap/src/lib/soap/multipart.ts
+++ b/projects/ngx-soap/src/lib/soap/multipart.ts
@@ -1,0 +1,60 @@
+export class Multipart  {
+  preambleCRLF = true;
+  postambleCRLF = true;
+
+  build(parts, boundary) {
+    const body = [];
+
+    function add (part) {
+      if (typeof part === 'number') {
+        part = part.toString();
+      }
+      return body.push(part)
+    }
+
+    if (this.preambleCRLF) {
+      add('\r\n')
+    }
+
+    parts.forEach(function (part) {
+      let preamble = '--' + boundary + '\r\n';
+      Object.keys(part).forEach(function (key) {
+        if (key === 'body') { return }
+        preamble += key + ': ' + part[key] + '\r\n'
+      });
+      preamble += '\r\n';
+      add(preamble);
+      add(part.body);
+      add('\r\n');
+    });
+    add('--' + boundary + '--');
+
+    if (this.postambleCRLF) {
+      add('\r\n');
+    }
+
+    const size = body.map((part) => {
+      if (typeof part === 'string') {
+        return part.length
+      } else {
+        return part.byteLength;
+      }
+    }).reduce((a, b) => a + b, 0);
+
+    let uint8array = new Uint8Array(size);
+    let i = 0;
+    body.forEach((part) => {
+      if (typeof part === 'string') {
+        for (let j = 0; j < part.length; i++, j++) {
+          uint8array[i] = part.charCodeAt(j) & 0xff;
+        }
+      } else {
+        for (let j = 0; j < part.byteLength; i++, j++) {
+          uint8array[i] = part[j];
+        }
+      }
+    });
+    return uint8array.buffer;
+  }
+
+}

--- a/projects/ngx-soap/src/lib/soap/soapAttachment.ts
+++ b/projects/ngx-soap/src/lib/soap/soapAttachment.ts
@@ -1,0 +1,32 @@
+export class SoapAttachment {
+
+  constructor(public mimetype: string,
+              public contentId: string,
+              public name: string,
+              public body: any
+  ) {
+
+  }
+
+  static fromFormFiles(files: FileList | File[]): Promise<any> {
+    if (files instanceof FileList) {
+      files = Array.from(files);
+    }
+
+    const promisses = files.map((file) => {
+      return new Promise(function(resolve) {
+        const reader = new FileReader();
+        reader.readAsArrayBuffer(file);
+        reader.onload = function (e) {
+          const arrayBuffer = (e.target as any).result;
+          const bytes = new Uint8Array(arrayBuffer);
+          const attachment = new SoapAttachment(file.type, file.name, file.name, bytes);
+          resolve(attachment);
+        }
+      });
+   });
+
+   return Promise.all(promisses);
+  }
+
+}

--- a/projects/ngx-soap/src/lib/soap/wsdl.ts
+++ b/projects/ngx-soap/src/lib/soap/wsdl.ts
@@ -10,10 +10,10 @@
 import * as sax from 'sax';
 import { HttpClient } from '@angular/common/http';
 import { NamespaceContext }  from './nscontext';
-
+import * as _ from 'lodash';
+import * as utils from './utils';
 import * as url from 'url';
 import { ok as assert } from 'assert';
-// import stripBom from 'strip-bom';
 
 const stripBom = (x: string): string => {
   // Catches EFBBBF (UTF-8 BOM) because the buffer-to-string
@@ -25,8 +25,7 @@ const stripBom = (x: string): string => {
   return x;
 }
 
-import * as _ from 'lodash';
-import * as utils from './utils';
+
 
 
 let TNS_PREFIX = utils.TNS_PREFIX;
@@ -2358,7 +2357,6 @@ export async function open_wsdl(uri, options): Promise<any> {
   // }
   // return wsdl;
 
-  console.log('Reading url: %s', uri);
   const httpClient: HttpClient = options.httpClient;
   const wsdlDef = await httpClient.get(uri, { responseType: 'text' }).toPromise();
   const wsdlObj = await new Promise((resolve) => {
@@ -2367,6 +2365,5 @@ export async function open_wsdl(uri, options): Promise<any> {
     wsdl.WSDL_CACHE = WSDL_CACHE;
     wsdl.onReady(resolve(wsdl));
   });
-  console.log("wsdl", wsdlObj)
   return wsdlObj;
 }


### PR DESCRIPTION
Attachments can now be added to a request in the options similiar to node-soap library.

Attachments should be of type FileList or File[]. Example:

const attachments: FileList | File[] = ...
(<any>this.client).Add(body, { attachments: attachments }).subscribe()