### PR TITLE
Fix setting contentId on files

### DIFF
--- a/projects/ngx-soap/src/lib/soap/soapAttachment.ts
+++ b/projects/ngx-soap/src/lib/soap/soapAttachment.ts
@@ -13,20 +13,20 @@ export class SoapAttachment {
       files = Array.from(files);
     }
 
-    const promisses = files.map((file) => {
+    const promisses = files.map((file: any) => {
       return new Promise(function(resolve) {
         const reader = new FileReader();
         reader.readAsArrayBuffer(file);
         reader.onload = function (e) {
           const arrayBuffer = (e.target as any).result;
           const bytes = new Uint8Array(arrayBuffer);
-          const attachment = new SoapAttachment(file.type, file.name, file.name, bytes);
+          const attachment = new SoapAttachment(file.type, file.contentId || file.name, file.name, bytes);
           resolve(attachment);
         }
       });
-   });
+    });
 
-   return Promise.all(promisses);
+    return Promise.all(promisses);
   }
 
 }


### PR DESCRIPTION
Added the ability to set a contentId that will be used in the MTOM file headers.